### PR TITLE
Rename package PEDS-243

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@gen3/guppy",
+  "name": "@pcdc/guppy",
   "version": "0.9.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcdc/guppy",
-  "version": "0.9.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcdc/guppy",
-  "version": "0.9.1",
+  "version": "0.1.2",
   "description": "Server that support GraphQL queries on data from elasticsearch",
   "main": "src/server/server.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@gen3/guppy",
+  "name": "@pcdc/guppy",
   "version": "0.9.1",
   "description": "Server that support GraphQL queries on data from elasticsearch",
   "main": "src/server/server.js",


### PR DESCRIPTION
For [PEDS-243](https://pcdc.atlassian.net/browse/PEDS-243)

This PR sets the package name to `@pcdc/guppy` and version to `"0.1.2"` to mark that we are ready to _own_ the guppy codebase and use it as such even though the most changes in the upstream will likely continue to be merged.