### PR TITLE
Enable user-defined initial filters PEDS-261

### DIFF
--- a/src/components/ConnectedFilter/index.jsx
+++ b/src/components/ConnectedFilter/index.jsx
@@ -41,7 +41,7 @@ class ConnectedFilter extends React.Component {
       accessibility: ENUM_ACCESSIBILITY.ALL,
       adminAppliedPreFilters: { ...this.props.adminAppliedPreFilters },
       filter: { ...initialFilter },
-      filtersApplied: {},
+      filtersApplied: { ...initialFilter },
     };
     this.filterGroupRef = React.createRef();
     this.adminPreFiltersFrozen = JSON.stringify(this.props.adminAppliedPreFilters).slice();

--- a/src/components/ConnectedFilter/index.jsx
+++ b/src/components/ConnectedFilter/index.jsx
@@ -273,6 +273,7 @@ class ConnectedFilter extends React.Component {
         filterConfig={filterConfig}
         onFilterChange={(e) => this.handleFilterChange(e)}
         hideZero={this.props.hideZero}
+        initialAppliedFilters={this.props.initialAppliedFilters}
       />
     );
   }
@@ -301,6 +302,7 @@ ConnectedFilter.propTypes = {
   onProcessFilterAggsData: PropTypes.func,
   onUpdateAccessLevel: PropTypes.func,
   adminAppliedPreFilters: PropTypes.object,
+  initialAppliedFilters: PropTypes.object,
   lockedTooltipMessage: PropTypes.string,
   disabledTooltipMessage: PropTypes.string,
   accessibleFieldCheckList: PropTypes.arrayOf(PropTypes.string),
@@ -321,6 +323,7 @@ ConnectedFilter.defaultProps = {
   onProcessFilterAggsData: (data) => (data),
   onUpdateAccessLevel: () => {},
   adminAppliedPreFilters: {},
+  initialAppliedFilters: {},
   lockedTooltipMessage: '',
   disabledTooltipMessage: '',
   accessibleFieldCheckList: undefined,

--- a/src/components/ConnectedFilter/index.jsx
+++ b/src/components/ConnectedFilter/index.jsx
@@ -53,7 +53,7 @@ class ConnectedFilter extends React.Component {
       this.props.onUpdateAccessLevel(this.state.accessibility);
     }
     if (this.props.onFilterChange) {
-      this.props.onFilterChange(this.state.adminAppliedPreFilters, this.state.accessibility);
+      this.props.onFilterChange(this.state.filter, this.state.accessibility);
     }
     askGuppyAboutAllFieldsAndOptions(
       this.props.guppyConfig.path,

--- a/src/components/ConnectedFilter/index.jsx
+++ b/src/components/ConnectedFilter/index.jsx
@@ -28,6 +28,10 @@ class ConnectedFilter extends React.Component {
     const allFields = props.accessibleFieldCheckList
       ? _.union(filterConfigsFields, props.accessibleFieldCheckList)
       : filterConfigsFields;
+    const initialFilter = mergeFilters(
+      props.initialAppliedFilters,
+      props.adminAppliedPreFilters,
+    );
 
     this.initialTabsOptions = {};
     this.state = {
@@ -36,7 +40,7 @@ class ConnectedFilter extends React.Component {
       receivedAggsData: {},
       accessibility: ENUM_ACCESSIBILITY.ALL,
       adminAppliedPreFilters: { ...this.props.adminAppliedPreFilters },
-      filter: { ...this.props.adminAppliedPreFilters },
+      filter: { ...initialFilter },
       filtersApplied: {},
     };
     this.filterGroupRef = React.createRef();


### PR DESCRIPTION
For [PEDS-261](https://pcdc.atlassian.net/browse/PEDS-261)

This PR adds a new `initialAppiledFilter` prop to `<ConnectdFilter>` component, which can be used to initialize filter using user-defined preset filter value, then also pass it to `<FilterGroup>` as prop. This makes possible for filter to "load" a preset value, which can be later modified by subsequent use interaction.

To fully enable this, `<FilterGroup>` component, which is provided to `<ConnectedFilter>` as prop, should also be modified to receive `initialAppliedFilter` as prop and use it to initialize filter status.