### PR TITLE
Modify filter value order PEDS-300

### DIFF
--- a/src/components/ConnectedFilter/index.jsx
+++ b/src/components/ConnectedFilter/index.jsx
@@ -17,7 +17,6 @@ import {
   mergeFilters,
   updateCountsInInitialTabsOptions,
   sortTabsOptions,
-  mergeTabOptions,
 } from '../Utils/filters';
 
 class ConnectedFilter extends React.Component {
@@ -165,74 +164,7 @@ class ConnectedFilter extends React.Component {
       this.props.tierAccessLimit ? this.props.accessibleFieldCheckList : [],
     );
 
-    if (Object.keys(this.state.filtersApplied).length) {
-      // if has applied filters, sort tab options as selected/unselected separately
-      const selectedTabsOptions = {};
-      const unselectedTabsOptions = {};
-      Object.keys(processedTabsOptions).forEach((opt) => {
-        if (!processedTabsOptions[`${opt}`].histogram.length) {
-          if (!unselectedTabsOptions[`${opt}`]) {
-            unselectedTabsOptions[`${opt}`] = {};
-          }
-          unselectedTabsOptions[`${opt}`].histogram = [];
-          return;
-        }
-        processedTabsOptions[`${opt}`].histogram.forEach((entry) => {
-          if (this.state.filtersApplied[`${opt}`]
-          && this.state.filtersApplied[`${opt}`].selectedValues
-          && this.state.filtersApplied[`${opt}`].selectedValues.includes(entry.key)) {
-            if (!selectedTabsOptions[`${opt}`]) {
-              selectedTabsOptions[`${opt}`] = {};
-            }
-            if (!selectedTabsOptions[`${opt}`].histogram) {
-              selectedTabsOptions[`${opt}`].histogram = [];
-            }
-            selectedTabsOptions[`${opt}`].histogram.push({ key: entry.key, count: entry.count });
-          } else {
-            if (!unselectedTabsOptions[`${opt}`]) {
-              unselectedTabsOptions[`${opt}`] = {};
-            }
-            if (typeof (entry.key) !== 'string') { // if it is a range filter, just copy and return
-              unselectedTabsOptions[`${opt}`].histogram = processedTabsOptions[`${opt}`].histogram;
-              return;
-            }
-            if (!unselectedTabsOptions[`${opt}`].histogram) {
-              unselectedTabsOptions[`${opt}`].histogram = [];
-            }
-            unselectedTabsOptions[`${opt}`].histogram.push({ key: entry.key, count: entry.count });
-          }
-        });
-      });
-
-      // For search filters: If there are any search filters present, include
-      // the selected options in the `selectedTabsOptions` array.
-      // ------
-      let allSearchFields = [];
-      this.props.filterConfig.tabs.forEach((tab) => {
-        allSearchFields = allSearchFields.concat(tab.searchFields);
-      });
-      allSearchFields.forEach((field) => {
-        if (this.state.filtersApplied[`${field}`]) {
-          const { selectedValues } = this.state.filtersApplied[`${field}`];
-          if (selectedValues) {
-            this.state.filtersApplied[`${field}`].selectedValues.forEach((val) => {
-              if (!selectedTabsOptions[`${field}`]) {
-                selectedTabsOptions[`${field}`] = {};
-              }
-              if (!selectedTabsOptions[`${field}`].histogram) {
-                selectedTabsOptions[`${field}`].histogram = [];
-              }
-              selectedTabsOptions[`${field}`].histogram.push({ key: val });
-            });
-          }
-        }
-      });
-      // -------
-      processedTabsOptions = mergeTabOptions(sortTabsOptions(selectedTabsOptions),
-        sortTabsOptions(unselectedTabsOptions));
-    } else {
-      processedTabsOptions = sortTabsOptions(processedTabsOptions);
-    }
+    processedTabsOptions = sortTabsOptions(processedTabsOptions);
 
     if (!processedTabsOptions || Object.keys(processedTabsOptions).length === 0) return null;
     const { fieldMapping } = this.props;

--- a/src/components/Utils/filters.js
+++ b/src/components/Utils/filters.js
@@ -117,13 +117,6 @@ export const updateCountsInInitialTabsOptions = (
   return updatedTabsOptions;
 };
 
-function sortCountThenAlpha(a, b) {
-  if (a.count === b.count) {
-    return a.key < b.key ? -1 : 1;
-  }
-  return b.count - a.count;
-}
-
 export const sortTabsOptions = (tabsOptions) => {
   const fields = Object.keys(tabsOptions);
   const sortedTabsOptions = { ...tabsOptions };
@@ -131,7 +124,7 @@ export const sortTabsOptions = (tabsOptions) => {
     const field = fields[x];
 
     const optionsForThisField = sortedTabsOptions[field].histogram;
-    optionsForThisField.sort(sortCountThenAlpha);
+    optionsForThisField.sort((a, b) => (a.key > b.key ? 1 : -1));
     sortedTabsOptions[field].histogram = optionsForThisField;
   }
   return sortedTabsOptions;

--- a/src/components/__tests__/filters.test.js
+++ b/src/components/__tests__/filters.test.js
@@ -197,8 +197,8 @@ describe('can sort tabs options', () => {
     },
     extra_data: {
       histogram: [
-        { key: 'a', count: 0 },
         { key: 'b', count: 0 },
+        { key: 'a', count: 0 },
         { key: 'c', count: 1 },
       ],
     },
@@ -207,20 +207,20 @@ describe('can sort tabs options', () => {
   const expectedSort = {
     annotated_sex: {
       histogram: [
-        { key: 'zorp', count: 4162 },
-        { key: 'yellow', count: 99 },
-        { key: 'orange', count: 30 },
-        { key: 'pink', count: 21 },
         { key: 'blue', count: 0 },
         { key: 'green', count: 0 },
+        { key: 'orange', count: 30 },
+        { key: 'pink', count: 21 },
         { key: 'shiny', count: 0 },
+        { key: 'yellow', count: 99 },
+        { key: 'zorp', count: 4162 },
       ],
     },
     extra_data: {
       histogram: [
-        { key: 'c', count: 1 },
         { key: 'a', count: 0 },
         { key: 'b', count: 0 },
+        { key: 'c', count: 1 },
       ],
     },
   };


### PR DESCRIPTION
Ticket: [PEDS-300](https://pcdc.atlassian.net/browse/PEDS-300)

This PR changes the sorting behavior for categorical filter values to keep the values in alphabetical order, regardless of the counts and select status.

See the images below for comparison.

Before:
<img width="337" alt="image" src="https://user-images.githubusercontent.com/22449454/110007983-dd2a7d80-7ce0-11eb-8d14-b0717737d09b.png">

After:
<img width="337" alt="image" src="https://user-images.githubusercontent.com/22449454/110007939-d26fe880-7ce0-11eb-8199-46cbc48777cb.png">
