### PR TITLE
Abort fetch from previous filter change PEDS-315

### DIFF
--- a/src/components/ConnectedFilter/index.jsx
+++ b/src/components/ConnectedFilter/index.jsx
@@ -111,6 +111,9 @@ class ConnectedFilter extends React.Component {
    * @param {object} filterResults
    */
   handleFilterChange(filterResults) {
+    this.controller.abort();
+    this.controller = new AbortController();
+
     const adminAppliedPreFilters = JSON.parse(this.adminPreFiltersFrozen);
     if (this._isMounted) this.setState({ adminAppliedPreFilters });
 

--- a/src/components/ConnectedFilter/index.jsx
+++ b/src/components/ConnectedFilter/index.jsx
@@ -46,6 +46,7 @@ class ConnectedFilter extends React.Component {
     this.adminPreFiltersFrozen = JSON.stringify(this.props.adminAppliedPreFilters).slice();
     this.arrayFields = [];
     this._isMounted = false;
+    this.controller = new AbortController();
   }
 
   componentDidMount() {
@@ -122,6 +123,7 @@ class ConnectedFilter extends React.Component {
       this.state.allFields,
       mergedFilterResults,
       this.state.accessibility,
+      this.controller.signal,
     )
       .then((res) => {
         this.handleReceiveNewAggsData(

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -64,6 +64,7 @@ class GuppyWrapper extends React.Component {
       adminAppliedPreFilters: { ...this.props.adminAppliedPreFilters },
     };
     this._isMounted = false;
+    this.controller = new AbortController();
   }
 
   componentDidMount() {
@@ -243,6 +244,7 @@ class GuppyWrapper extends React.Component {
         [],
         this.filter,
         this.state.accessibility,
+        this.controller.signal,
       ).then((res) => {
         if (!res || !res.data) {
           throw new Error(`Error getting raw ${this.props.guppyConfig.type} data from Guppy server ${this.props.guppyConfig.path}.`);
@@ -270,6 +272,7 @@ class GuppyWrapper extends React.Component {
       offset,
       size,
       this.state.accessibility,
+      this.controller.signal,
     ).then((res) => {
       if (!res || !res.data) {
         throw new Error(`Error getting raw ${this.props.guppyConfig.type} data from Guppy server ${this.props.guppyConfig.path}.`);

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -122,6 +122,7 @@ class GuppyWrapper extends React.Component {
     if (this._isMounted) {
       this.setState({ filter, accessibility }, () => {
         this.controller.abort();
+        this.controller = new AbortController();
         this.getDataFromGuppy(this.state.rawDataFields, undefined, true);
       });
     }

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -121,6 +121,7 @@ class GuppyWrapper extends React.Component {
     this.filter = filter;
     if (this._isMounted) {
       this.setState({ filter, accessibility }, () => {
+        this.controller.abort();
         this.getDataFromGuppy(this.state.rawDataFields, undefined, true);
       });
     }

--- a/src/components/Utils/queries.js
+++ b/src/components/Utils/queries.js
@@ -22,7 +22,7 @@ const histogramQueryStrForEachField = (field) => {
   }`);
 };
 
-const queryGuppyForAggs = (path, type, fields, gqlFilter, acc) => {
+const queryGuppyForAggs = (path, type, fields, gqlFilter, acc, signal) => {
   let accessibility = acc;
   if (accessibility !== 'all' && accessibility !== 'accessible' && accessibility !== 'unaccessible') {
     accessibility = 'all';
@@ -53,6 +53,7 @@ const queryGuppyForAggs = (path, type, fields, gqlFilter, acc) => {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify(queryBody),
+    signal,
   }).then((response) => response.json());
 };
 
@@ -272,9 +273,9 @@ export const askGuppyAboutAllFieldsAndOptions = (
 // eslint-disable-next-line max-len
 export const askGuppyAboutArrayTypes = (path) => queryGuppyForStatus(path).then((res) => res.indices);
 
-export const askGuppyForAggregationData = (path, type, fields, filter, accessibility) => {
+export const askGuppyForAggregationData = (path, type, fields, filter, accessibility, signal) => {
   const gqlFilter = getGQLFilter(filter);
-  return queryGuppyForAggs(path, type, fields, gqlFilter, accessibility);
+  return queryGuppyForAggs(path, type, fields, gqlFilter, accessibility, signal);
 };
 
 export const askGuppyForSubAggregationData = ({

--- a/src/components/Utils/queries.js
+++ b/src/components/Utils/queries.js
@@ -91,6 +91,7 @@ const queryGuppyForSubAgg = (
   missingFields,
   gqlFilter,
   acc,
+  signal,
 ) => {
   let accessibility = acc;
   if (accessibility !== 'all' && accessibility !== 'accessible' && accessibility !== 'unaccessible') {
@@ -131,6 +132,7 @@ const queryGuppyForSubAgg = (
       'Content-Type': 'application/json',
     },
     body: JSON.stringify(queryBody),
+    signal,
   }).then((response) => response.json())
     .catch((err) => {
       throw new Error(`Error during queryGuppyForSubAgg ${err}`);
@@ -160,6 +162,7 @@ export const queryGuppyForRawDataAndTotalCounts = (
   offset = 0,
   size = 20,
   accessibility = 'all',
+  signal,
 ) => {
   let queryLine = 'query {';
   if (gqlFilter || sort) {
@@ -194,6 +197,7 @@ export const queryGuppyForRawDataAndTotalCounts = (
       'Content-Type': 'application/json',
     },
     body: JSON.stringify(queryBody),
+    signal,
   }).then((response) => response.json())
     .catch((err) => {
       throw new Error(`Error during queryGuppyForRawDataAndTotalCounts ${err}`);
@@ -273,7 +277,7 @@ export const askGuppyForAggregationData = (path, type, fields, filter, accessibi
   return queryGuppyForAggs(path, type, fields, gqlFilter, accessibility);
 };
 
-export const askGuppyForSubAggregationData = (
+export const askGuppyForSubAggregationData = ({
   path,
   type,
   mainField,
@@ -282,7 +286,8 @@ export const askGuppyForSubAggregationData = (
   missedNestedFields,
   filter,
   accessibility,
-) => {
+  signal,
+}) => {
   const gqlFilter = getGQLFilter(filter);
   return queryGuppyForSubAgg(
     path,
@@ -293,6 +298,7 @@ export const askGuppyForSubAggregationData = (
     missedNestedFields,
     gqlFilter,
     accessibility,
+    signal,
   );
 };
 
@@ -305,6 +311,7 @@ export const askGuppyForRawData = (
   offset = 0,
   size = 20,
   accessibility = 'all',
+  signal,
 ) => {
   const gqlFilter = getGQLFilter(filter);
   return queryGuppyForRawDataAndTotalCounts(
@@ -316,6 +323,7 @@ export const askGuppyForRawData = (
     offset,
     size,
     accessibility,
+    signal,
   );
 };
 


### PR DESCRIPTION
Ticket: [PEDS-315](https://pcdc.atlassian.net/browse/PEDS-315)

This PR aborts data fetches from filter changes before completing them on new filter changes. This prevents serial data fetches and view updates on multiple filter changes, leading to better UX.

See the images below for comparison.

Before:
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/22449454/110043659-6c4d8a80-7d0d-11eb-9e4f-5db0f02ef58c.png">

After:
![image](https://user-images.githubusercontent.com/22449454/110043692-7c656a00-7d0d-11eb-9138-bbbc851c1943.png)