### PR TITLE
Fix user-defined initial fillters not applied in data requests PEDS-327

### DIFF
--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -328,6 +328,7 @@ class GuppyWrapper extends React.Component {
             onUpdateAccessLevel: this.handleAccessLevelUpdate.bind(this),
             adminAppliedPreFilters: this.props.adminAppliedPreFilters,
             accessibleFieldCheckList: this.props.accessibleFieldCheckList,
+            initialAppliedFilters: this.props.initialAppliedFilters,
           }))
         }
       </>
@@ -359,6 +360,7 @@ GuppyWrapper.propTypes = {
   onFilterChange: PropTypes.func,
   accessibleFieldCheckList: PropTypes.arrayOf(PropTypes.string),
   adminAppliedPreFilters: PropTypes.object,
+  initialAppliedFilters: PropTypes.object,
 };
 
 GuppyWrapper.defaultProps = {
@@ -367,6 +369,7 @@ GuppyWrapper.defaultProps = {
   rawDataFields: [],
   accessibleFieldCheckList: undefined,
   adminAppliedPreFilters: {},
+  initialAppliedFilters: {},
 };
 
 export default GuppyWrapper;

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -47,13 +47,18 @@ import { mergeFilters } from '../Utils/filters';
 class GuppyWrapper extends React.Component {
   constructor(props) {
     super(props);
+    const initialFilter = mergeFilters(
+      props.initialAppliedFilters,
+      props.adminAppliedPreFilters,
+    );
+
     // to avoid asynchronizations, we store another filter as private var
-    this.filter = { ...this.props.adminAppliedPreFilters };
+    this.filter = { ...initialFilter };
     this.adminPreFiltersFrozen = JSON.stringify(this.props.adminAppliedPreFilters).slice();
     this.state = {
       gettingDataFromGuppy: false,
       aggsData: {},
-      filter: { ...this.props.adminAppliedPreFilters },
+      filter: { ...initialFilter },
       rawData: [],
       totalCount: 0,
       allFields: [],


### PR DESCRIPTION
Ticket: [PEDS-327](https://pcdc.atlassian.net/browse/PEDS-327)

This PR fixes a bug where `<GuppyWrapper>`'s data requests to guppy server fails to account for `initialAppliedFilters`. The fixed behavior is part of the original intended use case of `initialAppliedFilters` that is first implemented in https://github.com/chicagopcdc/guppy/pull/10.