### PR TITLE
Derive totalCounts from aggsData PEDS-337

### DIFF
--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -109,7 +109,10 @@ class GuppyWrapper extends React.Component {
     if (this.props.onReceiveNewAggsData) {
       this.props.onReceiveNewAggsData(aggsData, this.filter);
     }
-    if (this._isMounted) this.setState({ aggsData });
+    if (this._isMounted) {
+      const totalCount = aggsData.project_id.histogram[0].count;
+      this.setState({ aggsData, totalCount });
+    }
   }
 
   handleFilterChange(userFilter, accessibility) {

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -294,14 +294,13 @@ class GuppyWrapper extends React.Component {
         throw new Error(`Error getting raw ${this.props.guppyConfig.type} data from Guppy server ${this.props.guppyConfig.path}.`);
       }
       const parsedData = res.data[this.props.guppyConfig.type];
-      const totalCount = res.data._aggregation[this.props.guppyConfig.type]._totalCount;
       if (this._isMounted) {
-        if (updateDataWhenReceive) this.setState({ rawData: parsedData, totalCount });
+        if (updateDataWhenReceive) this.setState({ rawData: parsedData });
         this.setState({ gettingDataFromGuppy: false });
       }
       return {
         data: parsedData,
-        totalCount,
+        totalCount: this.state.totalCount,
       };
     });
   }

--- a/src/components/Utils/queries.js
+++ b/src/components/Utils/queries.js
@@ -155,7 +155,7 @@ const rawDataQueryStrForEachField = (field) => {
   }`);
 };
 
-export const queryGuppyForRawDataAndTotalCounts = (
+export const queryGuppyForRawData = (
   path,
   type,
   fields,
@@ -175,19 +175,10 @@ export const queryGuppyForRawDataAndTotalCounts = (
   if (gqlFilter || sort || format) {
     dataTypeLine = `${type} (accessibility: ${accessibility}, offset: ${offset}, first: ${size}, ${format ? 'format: $format, ' : ''}, ${sort ? 'sort: $sort, ' : ''}${gqlFilter ? 'filter: $filter,' : ''}) {`;
   }
-  let typeAggsLine = `${type} accessibility: ${accessibility} {`;
-  if (gqlFilter) {
-    typeAggsLine = `${type} (filter: $filter, accessibility: ${accessibility}) {`;
-  }
   const processedFields = fields.map((field) => rawDataQueryStrForEachField(field));
   const query = `${queryLine}
     ${dataTypeLine}
       ${processedFields.join('\n')}
-    }
-    _aggregation {
-      ${typeAggsLine}
-        _totalCount
-      }
     }
   }`;
   const queryBody = { query };
@@ -204,7 +195,7 @@ export const queryGuppyForRawDataAndTotalCounts = (
     signal,
   }).then((response) => response.json())
     .catch((err) => {
-      throw new Error(`Error during queryGuppyForRawDataAndTotalCounts ${err}`);
+      throw new Error(`Error during queryGuppyForRawData ${err}`);
     });
 };
 
@@ -319,7 +310,7 @@ export const askGuppyForRawData = (
   format,
 ) => {
   const gqlFilter = getGQLFilter(filter);
-  return queryGuppyForRawDataAndTotalCounts(
+  return queryGuppyForRawData(
     path,
     type,
     fields,


### PR DESCRIPTION
Ticket: [PEDS-337](https://pcdc.atlassian.net/browse/PEDS-337)

This PR derives the `totalCount` value in `<GuppyWrapper>` from `aggsData`. This is based on PCDC's use case where the aggregated data for a repurposed filter `project_id` (now used for Data Release Version) always holds the count of the all subjects.

With this change, `totalCount` is updated before raw (i.e. line-level) data for table view is fetched/updated, thus leading to a more consistent UX where all elements in the summary view are updated together. This also makes possible to isolate updating table view from updating the rest of the exploration page, allowing the user to start interacting with the exploration page while the table view is updating.