### PR TITLE
Fix search filter option loader PEDS-350

### DIFF
--- a/src/components/ConnectedFilter/utils.js
+++ b/src/components/ConnectedFilter/utils.js
@@ -1,5 +1,5 @@
 import flat from 'flat';
-import { queryGuppyForRawDataAndTotalCounts } from '../Utils/queries';
+import { queryGuppyForRawData } from '../Utils/queries';
 
 export const getFilterGroupConfig = (filterConfig) => ({
   tabs: filterConfig.tabs.map((t) => ({
@@ -60,7 +60,7 @@ const createSearchFilterLoadOptionsFn = (field, guppyConfig) => (searchString, o
         },
       };
     }
-    queryGuppyForRawDataAndTotalCounts(
+    queryGuppyForRawData(
       guppyConfig.path,
       guppyConfig.type,
       [field],
@@ -69,6 +69,7 @@ const createSearchFilterLoadOptionsFn = (field, guppyConfig) => (searchString, o
       offset,
       NUM_SEARCH_OPTIONS,
       'accessible',
+      true,
     )
       .then((res) => {
         if (!res.data || !res.data[guppyConfig.type]) {

--- a/src/components/Utils/queries.js
+++ b/src/components/Utils/queries.js
@@ -166,6 +166,7 @@ export const queryGuppyForRawData = (
   accessibility = 'all',
   signal,
   format,
+  withTotalCount = false,
 ) => {
   let queryLine = 'query {';
   if (gqlFilter || sort || format) {
@@ -175,11 +176,20 @@ export const queryGuppyForRawData = (
   if (gqlFilter || sort || format) {
     dataTypeLine = `${type} (accessibility: ${accessibility}, offset: ${offset}, first: ${size}, ${format ? 'format: $format, ' : ''}, ${sort ? 'sort: $sort, ' : ''}${gqlFilter ? 'filter: $filter,' : ''}) {`;
   }
+  let totalCountFragment = '';
+  if (withTotalCount) {
+    totalCountFragment = `_aggregation {
+      ${type} (${gqlFilter ? 'filter: $filter, ' : ''}accessibility: ${accessibility}) {
+        _totalCount
+      }
+    }`;
+  }
   const processedFields = fields.map((field) => rawDataQueryStrForEachField(field));
   const query = `${queryLine}
     ${dataTypeLine}
       ${processedFields.join('\n')}
     }
+    ${totalCountFragment}
   }`;
   const queryBody = { query };
   queryBody.variables = {};
@@ -308,6 +318,7 @@ export const askGuppyForRawData = (
   accessibility = 'all',
   signal,
   format,
+  withTotalCount,
 ) => {
   const gqlFilter = getGQLFilter(filter);
   return queryGuppyForRawData(
@@ -321,6 +332,7 @@ export const askGuppyForRawData = (
     accessibility,
     signal,
     format,
+    withTotalCount,
   );
 };
 


### PR DESCRIPTION
Ticket: [PEDS-350](https://pcdc.atlassian.net/browse/PEDS-350)

This PR fixes a bug caused by #26 which replaces `queryGuppyForRawDataAndTotalCounts` query util function with `queryGuppyForRawData`, without modifying `createSearchFilterLoadOptionsFn` function body that invokes `queryGuppyForRawDataAndTotalCounts`.

This bug was missed because the PCDC portal currently does not use `searchFilter`, the only filter type that uses `createSearchFilterLoadOptionsFn`.

The fix involves adding a boolean `withTotalCount` param to `queryGuppyForRawData` so that `totalCount` data can be fetched if needed and using it inside `createSearchFilterLoadOptionsFn`.