### PR TITLE
Set accessibility in queries PEDS-348

### DIFF
--- a/src/components/ConnectedFilter/index.jsx
+++ b/src/components/ConnectedFilter/index.jsx
@@ -62,7 +62,6 @@ class ConnectedFilter extends React.Component {
       this.props.guppyConfig.path,
       this.props.guppyConfig.type,
       this.state.allFields,
-      this.state.accessibility,
       this.state.filter,
     )
       .then((res) => {
@@ -125,7 +124,6 @@ class ConnectedFilter extends React.Component {
       this.props.guppyConfig.type,
       this.state.allFields,
       mergedFilterResults,
-      this.state.accessibility,
       this.controller.signal,
     )
       .then((res) => {

--- a/src/components/ConnectedFilter/index.jsx
+++ b/src/components/ConnectedFilter/index.jsx
@@ -8,7 +8,6 @@ import {
 } from './utils';
 import { ENUM_ACCESSIBILITY } from '../Utils/const';
 import {
-  askGuppyAboutAllFieldsAndOptions,
   askGuppyAboutArrayTypes,
   askGuppyForAggregationData,
   getAllFieldsFromFilterConfigs,
@@ -58,7 +57,7 @@ class ConnectedFilter extends React.Component {
     if (this.props.onFilterChange) {
       this.props.onFilterChange(this.state.filter, this.state.accessibility);
     }
-    askGuppyAboutAllFieldsAndOptions(
+    askGuppyForAggregationData(
       this.props.guppyConfig.path,
       this.props.guppyConfig.type,
       this.state.allFields,

--- a/src/components/ConnectedFilter/utils.js
+++ b/src/components/ConnectedFilter/utils.js
@@ -68,7 +68,6 @@ const createSearchFilterLoadOptionsFn = (field, guppyConfig) => (searchString, o
       undefined,
       offset,
       NUM_SEARCH_OPTIONS,
-      'accessible',
       true,
     )
       .then((res) => {

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -178,10 +178,6 @@ class GuppyWrapper extends React.Component {
    * This function uses current filter argument
    */
   handleDownloadRawDataByFields({ fields, sort = [] }) {
-    let targetFields = fields;
-    if (typeof fields === 'undefined') {
-      targetFields = this.state.rawDataFields;
-    }
     return askGuppyForTotalCounts(
       this.props.guppyConfig.path,
       this.props.guppyConfig.type,
@@ -192,7 +188,7 @@ class GuppyWrapper extends React.Component {
       this.props.guppyConfig.type,
       count,
       {
-        fields: targetFields,
+        fields: fields || this.state.rawDataFields,
         sort,
         filter: this.state.filter,
       },

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -203,7 +203,8 @@ class GuppyWrapper extends React.Component {
   handleAskGuppyForTotalCounts(type, filter) {
     return askGuppyForTotalCounts(
       this.props.guppyConfig.path,
-      type, filter,
+      type,
+      filter,
       this.state.accessibility,
     );
   }

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -286,7 +286,6 @@ class GuppyWrapper extends React.Component {
       sort,
       offset,
       size,
-      this.state.accessibility,
       this.controller.signal,
     ).then((res) => {
       if (!res || !res.data) {

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -259,7 +259,6 @@ class GuppyWrapper extends React.Component {
         this.props.guppyConfig.aggFields,
         [],
         this.filter,
-        this.state.accessibility,
         this.controller.signal,
       ).then((res) => {
         if (!res || !res.data) {

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -162,7 +162,6 @@ class GuppyWrapper extends React.Component {
         fields: this.state.rawDataFields,
         sort: sort || [],
         filter: this.state.filter,
-        accessibility: this.state.accessibility,
         format,
       },
     );
@@ -186,7 +185,6 @@ class GuppyWrapper extends React.Component {
         fields: targetFields,
         sort,
         filter: this.state.filter,
-        accessibility: this.state.accessibility,
       },
     );
   }

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -154,17 +154,22 @@ class GuppyWrapper extends React.Component {
       // eslint-disable-next-line no-console
       console.error(`Invalid value ${format} found for arg format!`);
     }
-    return downloadDataFromGuppy(
+    return askGuppyForTotalCounts(
       this.props.guppyConfig.path,
       this.props.guppyConfig.type,
-      this.state.totalCount,
+      this.state.filter,
+      'accessible',
+    ).then((count) => downloadDataFromGuppy(
+      this.props.guppyConfig.path,
+      this.props.guppyConfig.type,
+      count,
       {
         fields: this.state.rawDataFields,
         sort: sort || [],
         filter: this.state.filter,
         format,
       },
-    );
+    ));
   }
 
   /**
@@ -177,16 +182,21 @@ class GuppyWrapper extends React.Component {
     if (typeof fields === 'undefined') {
       targetFields = this.state.rawDataFields;
     }
-    return downloadDataFromGuppy(
+    return askGuppyForTotalCounts(
       this.props.guppyConfig.path,
       this.props.guppyConfig.type,
-      this.state.totalCount,
+      this.state.filter,
+      'accessible',
+    ).then((count) => downloadDataFromGuppy(
+      this.props.guppyConfig.path,
+      this.props.guppyConfig.type,
+      count,
       {
         fields: targetFields,
         sort,
         filter: this.state.filter,
       },
-    );
+    ));
   }
 
   /**
@@ -213,17 +223,16 @@ class GuppyWrapper extends React.Component {
       this.props.guppyConfig.path,
       type,
       filter,
-      this.state.accessibility,
-    )
-      .then((count) => downloadDataFromGuppy(
-        this.props.guppyConfig.path,
-        type,
-        count,
-        {
-          fields,
-          filter,
-        },
-      ));
+      'accessible',
+    ).then((count) => downloadDataFromGuppy(
+      this.props.guppyConfig.path,
+      type,
+      count,
+      {
+        fields,
+        filter,
+      },
+    ));
   }
 
   handleAccessLevelUpdate(accessLevel) {

--- a/src/components/Utils/queries.js
+++ b/src/components/Utils/queries.js
@@ -324,7 +324,7 @@ export const getAllFieldsFromFilterConfigs = (filterTabConfigs) => filterTabConf
 export const downloadDataFromGuppy = (
   path,
   type,
-  totalCount,
+  size,
   {
     fields,
     filter,
@@ -334,7 +334,7 @@ export const downloadDataFromGuppy = (
 ) => {
   const SCROLL_SIZE = 10000;
   const JSON_FORMAT = (format === 'json' || format === undefined);
-  if (totalCount > SCROLL_SIZE) {
+  if (size > SCROLL_SIZE) {
     const queryBody = { type, accessibility: 'accessible' };
     if (fields) queryBody.fields = fields;
     if (filter) queryBody.filter = getGQLFilter(filter);
@@ -347,7 +347,7 @@ export const downloadDataFromGuppy = (
       body: JSON.stringify(queryBody),
     }).then((res) => (JSON_FORMAT ? res.json() : jsonToFormat(res.json(), format)));
   }
-  return askGuppyForRawData(path, type, fields, filter, sort, 0, totalCount, format)
+  return askGuppyForRawData(path, type, fields, filter, sort, 0, size, format)
     .then((res) => {
       if (res && res.data && res.data[type]) {
         return JSON_FORMAT ? res.data[type] : jsonToFormat(res.data[type], format);

--- a/src/components/Utils/queries.js
+++ b/src/components/Utils/queries.js
@@ -262,11 +262,6 @@ export const getGQLFilter = (filterObj) => {
   return gqlFilter;
 };
 
-export const askGuppyAboutAllFieldsAndOptions = (path, type, fields, filter) => {
-  const gqlFilter = getGQLFilter(filter);
-  return queryGuppyForAggs(path, type, fields, gqlFilter);
-};
-
 // eslint-disable-next-line max-len
 export const askGuppyAboutArrayTypes = (path) => queryGuppyForStatus(path).then((res) => res.indices);
 

--- a/src/components/Utils/queries.js
+++ b/src/components/Utils/queries.js
@@ -23,15 +23,10 @@ const histogramQueryStrForEachField = (field) => {
   }`);
 };
 
-const queryGuppyForAggs = (path, type, fields, gqlFilter, acc, signal) => {
-  let accessibility = acc;
-  if (accessibility !== 'all' && accessibility !== 'accessible' && accessibility !== 'unaccessible') {
-    accessibility = 'all';
-  }
-
+const queryGuppyForAggs = (path, type, fields, gqlFilter, signal) => {
   const query = `query {
     _aggregation {
-      ${type} (accessibility: ${accessibility}) {
+      ${type} (accessibility: all) {
         ${fields.map((field) => histogramQueryStrForEachField(field))}
       }
     }
@@ -40,7 +35,7 @@ const queryGuppyForAggs = (path, type, fields, gqlFilter, acc, signal) => {
   if (gqlFilter) {
     const queryWithFilter = `query ($filter: JSON) {
       _aggregation {
-        ${type} (filter: $filter, filterSelf: false, accessibility: ${accessibility}) {
+        ${type} (filter: $filter, filterSelf: false, accessibility: all}) {
           ${fields.map((field) => histogramQueryStrForEachField(field))}
         }
       }
@@ -267,19 +262,17 @@ export const getGQLFilter = (filterObj) => {
   return gqlFilter;
 };
 
-export const askGuppyAboutAllFieldsAndOptions = (
-  path, type, fields, accessibility, filter,
-) => {
+export const askGuppyAboutAllFieldsAndOptions = (path, type, fields, filter) => {
   const gqlFilter = getGQLFilter(filter);
-  return queryGuppyForAggs(path, type, fields, gqlFilter, accessibility);
+  return queryGuppyForAggs(path, type, fields, gqlFilter);
 };
 
 // eslint-disable-next-line max-len
 export const askGuppyAboutArrayTypes = (path) => queryGuppyForStatus(path).then((res) => res.indices);
 
-export const askGuppyForAggregationData = (path, type, fields, filter, accessibility, signal) => {
+export const askGuppyForAggregationData = (path, type, fields, filter, signal) => {
   const gqlFilter = getGQLFilter(filter);
-  return queryGuppyForAggs(path, type, fields, gqlFilter, accessibility, signal);
+  return queryGuppyForAggs(path, type, fields, gqlFilter, signal);
 };
 
 export const askGuppyForSubAggregationData = ({

--- a/src/components/Utils/queries.js
+++ b/src/components/Utils/queries.js
@@ -329,18 +329,16 @@ export const downloadDataFromGuppy = (
     fields,
     filter,
     sort,
-    accessibility,
     format,
   },
 ) => {
   const SCROLL_SIZE = 10000;
   const JSON_FORMAT = (format === 'json' || format === undefined);
   if (totalCount > SCROLL_SIZE) {
-    const queryBody = { type };
+    const queryBody = { type, accessibility: 'accessible' };
     if (fields) queryBody.fields = fields;
     if (filter) queryBody.filter = getGQLFilter(filter);
     if (sort) queryBody.sort = sort;
-    if (typeof accessibility !== 'undefined') queryBody.accessibility = accessibility;
     return fetch(`${path}${downloadEndpoint}`, {
       method: 'POST',
       headers: {

--- a/src/components/Utils/queries.js
+++ b/src/components/Utils/queries.js
@@ -35,7 +35,7 @@ const queryGuppyForAggs = (path, type, fields, gqlFilter, signal) => {
   if (gqlFilter) {
     const queryWithFilter = `query ($filter: JSON) {
       _aggregation {
-        ${type} (filter: $filter, filterSelf: false, accessibility: all}) {
+        ${type} (filter: $filter, filterSelf: false, accessibility: all) {
           ${fields.map((field) => histogramQueryStrForEachField(field))}
         }
       }

--- a/src/components/Utils/queries.js
+++ b/src/components/Utils/queries.js
@@ -152,7 +152,6 @@ export const queryGuppyForRawData = (
   sort,
   offset = 0,
   size = 20,
-  accessibility = 'all',
   signal,
   format,
   withTotalCount = false,
@@ -161,14 +160,14 @@ export const queryGuppyForRawData = (
   if (gqlFilter || sort || format) {
     queryLine = `query (${sort ? '$sort: JSON,' : ''}${gqlFilter ? '$filter: JSON,' : ''}${format ? '$format: Format' : ''}) {`;
   }
-  let dataTypeLine = `${type} (accessibility: ${accessibility}, offset: ${offset}, first: ${size}, format: $format) {`;
+  let dataTypeLine = `${type} (accessibility: accessible, offset: ${offset}, first: ${size}, format: $format) {`;
   if (gqlFilter || sort || format) {
-    dataTypeLine = `${type} (accessibility: ${accessibility}, offset: ${offset}, first: ${size}, ${format ? 'format: $format, ' : ''}, ${sort ? 'sort: $sort, ' : ''}${gqlFilter ? 'filter: $filter,' : ''}) {`;
+    dataTypeLine = `${type} (accessibility: accessible, offset: ${offset}, first: ${size}, ${format ? 'format: $format, ' : ''}, ${sort ? 'sort: $sort, ' : ''}${gqlFilter ? 'filter: $filter,' : ''}) {`;
   }
   let totalCountFragment = '';
   if (withTotalCount) {
     totalCountFragment = `_aggregation {
-      ${type} (${gqlFilter ? 'filter: $filter, ' : ''}accessibility: ${accessibility}) {
+      ${type} (${gqlFilter ? 'filter: $filter, ' : ''}accessibility: accessible) {
         _totalCount
       }
     }`;
@@ -295,7 +294,6 @@ export const askGuppyForRawData = (
   sort,
   offset = 0,
   size = 20,
-  accessibility = 'all',
   signal,
   format,
   withTotalCount,
@@ -309,7 +307,6 @@ export const askGuppyForRawData = (
     sort,
     offset,
     size,
-    accessibility,
     signal,
     format,
     withTotalCount,
@@ -352,7 +349,7 @@ export const downloadDataFromGuppy = (
       body: JSON.stringify(queryBody),
     }).then((res) => (JSON_FORMAT ? res.json() : jsonToFormat(res.json(), format)));
   }
-  return askGuppyForRawData(path, type, fields, filter, sort, 0, totalCount, accessibility, format)
+  return askGuppyForRawData(path, type, fields, filter, sort, 0, totalCount, format)
     .then((res) => {
       if (res && res.data && res.data[type]) {
         return JSON_FORMAT ? res.data[type] : jsonToFormat(res.data[type], format);

--- a/src/components/Utils/queries.js
+++ b/src/components/Utils/queries.js
@@ -87,14 +87,8 @@ const queryGuppyForSubAgg = (
   termsFields,
   missingFields,
   gqlFilter,
-  acc,
   signal,
 ) => {
-  let accessibility = acc;
-  if (accessibility !== 'all' && accessibility !== 'accessible' && accessibility !== 'unaccessible') {
-    accessibility = 'all';
-  }
-
   const nestedAggFields = {};
   if (termsFields) {
     nestedAggFields.termsFields = termsFields;
@@ -105,7 +99,7 @@ const queryGuppyForSubAgg = (
 
   const query = `query ($nestedAggFields: JSON) {
     _aggregation {
-      ${type} (nestedAggFields: $nestedAggFields, accessibility: ${accessibility}) {
+      ${type} (nestedAggFields: $nestedAggFields, accessibility: all) {
         ${nestedHistogramQueryStrForEachField(mainField, numericAggAsText)}
       }
     }
@@ -115,7 +109,7 @@ const queryGuppyForSubAgg = (
   if (gqlFilter) {
     const queryWithFilter = `query ($filter: JSON, $nestedAggFields: JSON) {
       _aggregation {
-        ${type} (filter: $filter, filterSelf: false, nestedAggFields: $nestedAggFields, accessibility: ${accessibility}) {
+        ${type} (filter: $filter, filterSelf: false, nestedAggFields: $nestedAggFields, accessibility: all) {
           ${nestedHistogramQueryStrForEachField(mainField, numericAggAsText)}
         }
       }
@@ -278,7 +272,6 @@ export const askGuppyForSubAggregationData = ({
   termsNestedFields,
   missedNestedFields,
   filter,
-  accessibility,
   signal,
 }) => {
   const gqlFilter = getGQLFilter(filter);
@@ -290,7 +283,6 @@ export const askGuppyForSubAggregationData = ({
     termsNestedFields,
     missedNestedFields,
     gqlFilter,
-    accessibility,
     signal,
   );
 };


### PR DESCRIPTION
Ticket: [PEDS-348](https://pcdc.atlassian.net/browse/PEDS-348)

This PR sets accessibility argument to a fixed value for each graphql query based on PCDC portal use case:

* `accessibility: all` for queries with aggregate data
* `accessibility: accessible` for queries with raw data

One exception is `askGuppyForTotalCounts()`, which keeps the `accessibility` parameter. This is currently used in the portal by `<ExplorerButtonGroup>` to set/update `manifestEntryCount` state. The reason for this exception: PCDC portal does not use `manifest` button type in `dataExplorerConfig.buttons` configuration, so it's difficult to test the implications of setting the accessibility to a fixed value for `askGuppyForTotalCounts()`.

This PR also contains some refactoring to improve code quality.