### PR TITLE
Use accessible count state PEDS-351 PEDS-360

### DIFF
--- a/src/components/ConnectedFilter/index.jsx
+++ b/src/components/ConnectedFilter/index.jsx
@@ -70,6 +70,8 @@ class ConnectedFilter extends React.Component {
         }
         this.handleReceiveNewAggsData(
           res.data._aggregation[this.props.guppyConfig.type],
+          res.data._aggregation.accessible._totalCount,
+          res.data._aggregation.all._totalCount,
           this.state.adminAppliedPreFilters,
         );
         this.saveInitialAggsData(res.data._aggregation[this.props.guppyConfig.type]);
@@ -91,11 +93,16 @@ class ConnectedFilter extends React.Component {
     this._isMounted = false;
   }
 
-  handleReceiveNewAggsData(receivedAggsData, filterResults) {
+  handleReceiveNewAggsData(
+    receivedAggsData,
+    accessibleCount,
+    totalCount,
+    filterResults,
+  ) {
     if (this._isMounted) this.setState({ receivedAggsData });
     if (this.props.onReceiveNewAggsData) {
       const resultAggsData = excludeSelfFilterFromAggsData(receivedAggsData, filterResults);
-      this.props.onReceiveNewAggsData(resultAggsData);
+      this.props.onReceiveNewAggsData(resultAggsData, accessibleCount, totalCount);
     }
   }
 
@@ -128,6 +135,8 @@ class ConnectedFilter extends React.Component {
       .then((res) => {
         this.handleReceiveNewAggsData(
           res.data._aggregation[this.props.guppyConfig.type],
+          res.data._aggregation.accessible._totalCount,
+          res.data._aggregation.all._totalCount,
           mergedFilterResults,
         );
       });

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -60,6 +60,7 @@ class GuppyWrapper extends React.Component {
       aggsData: {},
       filter: { ...initialFilter },
       rawData: [],
+      accessibleCount: 0,
       totalCount: 0,
       allFields: [],
       rawDataFields: [],
@@ -318,6 +319,7 @@ class GuppyWrapper extends React.Component {
             filter: this.state.filter,
             filterConfig: this.props.filterConfig,
             rawData: this.state.rawData, // raw data (with current filter applied)
+            accessibleCount: this.state.accessibleCount,
             totalCount: this.state.totalCount, // total count of raw data (current filter applied)
             fetchAndUpdateRawData: this.handleFetchAndUpdateRawData.bind(this),
             downloadRawData: this.handleDownloadRawData.bind(this),

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -106,14 +106,11 @@ class GuppyWrapper extends React.Component {
     this._isMounted = false;
   }
 
-  handleReceiveNewAggsData(aggsData) {
+  handleReceiveNewAggsData(aggsData, accessibleCount, totalCount) {
     if (this.props.onReceiveNewAggsData) {
       this.props.onReceiveNewAggsData(aggsData, this.filter);
     }
-    if (this._isMounted) {
-      const totalCount = aggsData.project_id.histogram[0].count;
-      this.setState({ aggsData, totalCount });
-    }
+    if (this._isMounted) this.setState({ aggsData, accessibleCount, totalCount });
   }
 
   handleFilterChange(userFilter, accessibility) {

--- a/src/components/Utils/queries.js
+++ b/src/components/Utils/queries.js
@@ -29,6 +29,12 @@ const queryGuppyForAggs = (path, type, fields, gqlFilter, signal) => {
       ${type} (accessibility: all) {
         ${fields.map((field) => histogramQueryStrForEachField(field))}
       }
+      accessible: ${type} (accessibility: accessible) {
+        _totalCount
+      }
+      all: ${type} (accessibility: all) {
+        _totalCount
+      }
     }
   }`;
   const queryBody = { query };
@@ -37,6 +43,12 @@ const queryGuppyForAggs = (path, type, fields, gqlFilter, signal) => {
       _aggregation {
         ${type} (filter: $filter, filterSelf: false, accessibility: all) {
           ${fields.map((field) => histogramQueryStrForEachField(field))}
+        }
+        accessible: ${type} (filter: $filter, accessibility: accessible) {
+          _totalCount
+        }
+        all: ${type} (filter: $filter, accessibility: all) {
+          _totalCount
         }
       }
     }`;


### PR DESCRIPTION
Tickets: [PEDS-351](https://pcdc.atlassian.net/browse/PEDS-351), [PEDS-360](https://pcdc.atlassian.net/browse/PEDS-360)

This PR adds `accessibleCount` to `<GuppyWrapper>` state, which can be later used to display the number of accessible data in Explorer UI. This PR also modifies `queryGuppyForAggs()` util function for it to fetch the counts data as well and use them to update counts state  in the `<GuppyWrapper>`.