### PR TITLE
adding a Helm quickstart guide to Guppy service (#169)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ Run `npm start` to start server at port 80.
 ### Local Deployment and Development:
 Guppy has some helper script to help a developer to set up a local ES service using Docker, generate some example ES indices for testing, and pop mock data into these example ES indices. Please refer to [the DEV Helper doc](https://github.com/uc-cdis/guppy/blob/master/devHelper/README.md) for more information.
 
+### Quickstart with Helm
+
+You can now deploy individual services via Helm!
+Please refer to the Helm quickstart guide HERE (https://github.com/uc-cdis/guppy/blob/master/doc/quickstart_helm.md)
+
 ### Configurations:
 Before launch, we need to write config and tell Guppy which elasticsearch indices and which auth control field to use.
 You could put following as your config files:

--- a/doc/quickstart_helm.md
+++ b/doc/quickstart_helm.md
@@ -1,0 +1,45 @@
+## Quickstart with Helm
+
+If you are looking to deploy all Gen3 services, that can be done via the Gen3 Helm chart.
+Instructions for deploying all Gen3 services with Helm can be found [here](https://github.com/uc-cdis/gen3-helm#readme).
+
+To deploy the guppy service:
+```bash
+helm repo add gen3 https://helm.gen3.org
+helm repo update
+helm upgrade --install gen3/guppy
+```
+These commands will add the Gen3 helm chart repo and install the guppy service to your Kubernetes cluster.
+
+Deploying guppy this way will use the defaults that are defined in this [values.yaml file](https://github.com/uc-cdis/gen3-helm/blob/master/helm/guppy/values.yaml)
+
+You can learn more about these values by accessing the guppy [README.md](https://github.com/uc-cdis/gen3-helm/blob/master/helm/guppy/README.md)
+
+If you would like to override any of the default values, simply copy the above values.yaml file into a local file and make any changes needed.
+
+You can then supply your new values file with the following command:
+```bash
+helm upgrade --install gen3/guppy -f values.yaml
+```
+
+If you are using Docker Build to create new images for testing, you can deploy them via Helm by replacing the .image.repository value with the name of your local image.
+You will also want to set the .image.pullPolicy to "never" so kubernetes will look locally for your image.
+Here is an example:
+```bash
+image:
+  repository: <image name from docker image ls>
+  pullPolicy: Never
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+```
+
+Re-run the following command to update your helm deployment to use the new image:
+```bash
+helm upgrade --install gen3/guppy
+```
+
+You can also store your images in a local registry. Kind and Minikube are popular for their local registries:
+- https://kind.sigs.k8s.io/docs/user/local-registry/
+- https://minikube.sigs.k8s.io/docs/handbook/registry/#enabling-insecure-registries
+
+Note: Guppy relies on elasticsearch to run. Please view the [Elasticsearch Helm chart](https://github.com/uc-cdis/gen3-helm/tree/master/helm/elasticsearch) for more information.


### PR DESCRIPTION
* adding a Helm quickstart guide to guppy service

* removed postgres section from guppy

* adding a separate doc for the quickstart Helm guide

* adding the link to the separate helm quickstart guide

* adding an extra space